### PR TITLE
Auto-generate Group and Policy names

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,11 +11,11 @@ By default, when you create a member account as part of your Organization, AWS a
 
 The role grants admin permissions to access the member account to delegated IAM users in the master account.
 
-In the master account you need to create a Policy to grant permissions to the IAM users to assume `OrganizationAccountAccessRole` in the member account.
+In the master account you need to create a Policy to grant permissions to IAM users to assume `OrganizationAccountAccessRole` in the member account.
 
 This module does the following:
 
-1. Creates an IAM Group with the specified name
+1. Creates an IAM Group
 2. Adds the provided IAM users to the Group
 3. Creates a Policy to grant permissions to the IAM users in the master account to assume `OrganizationAccountAccessRole` in the member account
 4. Attaches the Policy to the Group
@@ -46,11 +46,11 @@ You can use [terraform-aws-organization-access-role](https://github.com/cloudpos
 ```hcl
 module "organization_access_group" {
   source            = "git::https://github.com/cloudposse/terraform-aws-organization-access-group.git?ref=master"
-  group_name        = "OrganizationGroup"
+  namespace         = "cp"
+  stage             = "dev"
+  name              = "cluster"
   user_names        = ["User1","User2"]
-  member_account_id = "XXXXXXXXXXXX"
-  role_name         = "OrganizationAccountAccessRole"
-  policy_name       = "OrganizationAccountAccessPolicy"
+  member_account_id = "XXXXXXXXXXXXXX"
 }
 ```
 
@@ -59,11 +59,15 @@ module "organization_access_group" {
 
 |  Name                 |  Default                          |  Description                                                                             | Required |
 |:----------------------|:----------------------------------|:-----------------------------------------------------------------------------------------|:--------:|
-| `group_name`          | ``                                | The name of the Group                                                                    | Yes      |
+| `namespace`           | ``                                | Namespace (_e.g._ `cp` or `cloudposse`)                                                  | Yes      |
+| `stage`               | ``                                | Stage (_e.g._ `prod`, `dev`, `staging`)                                                  | Yes      |
+| `name`                | ``                                | Name  (_e.g._ `app` or `cluster`)                                                        | Yes      |
 | `user_names`          | ``                                | A list of IAM User names to associate with the Group                                     | Yes      |
 | `member_account_id`   | ``                                | The ID of the member account to grant access permissions to the users in the Group       | Yes      |
-| `role_name`           | `OrganizationAccountAccessRole`   | The name of the role in the member account to grant permissions to delegated IAM users   | No       |
-| `policy_name`         | `OrganizationAccountAccessPolicy` | The name of the policy to attach to the Group                                            | No       |
+| `role_name`           | `OrganizationAccountAccessRole`   | The name of the Role in the member account to grant permissions to the users in the Group   | No       |
+| `attributes`          | `[]`                              | Additional attributes (_e.g._ `policy` or `role`)                                        | No       |
+| `tags`                | `{}`                              | Additional tags  (_e.g._ `map("BusinessUnit","XYZ")`                                     | No       |
+| `delimiter`           | `-`                               | Delimiter to be used between `namespace`, `stage`, `name`, and `attributes`              | No       |
 
 
 ## Outputs

--- a/main.tf
+++ b/main.tf
@@ -1,11 +1,21 @@
+module "label" {
+  source     = "git::https://github.com/cloudposse/terraform-null-label.git?ref=tags/0.3.3"
+  namespace  = "${var.namespace}"
+  name       = "${var.name}"
+  stage      = "${var.stage}"
+  delimiter  = "${var.delimiter}"
+  attributes = "${var.attributes}"
+  tags       = "${var.tags}"
+}
+
 # https://www.terraform.io/docs/providers/aws/r/iam_group.html
 resource "aws_iam_group" "default" {
-  name = "${var.group_name}"
+  name = "${module.label.id}${var.delimiter}group"
 }
 
 # https://www.terraform.io/docs/providers/aws/r/iam_group_membership.html
 resource "aws_iam_group_membership" "default" {
-  name  = "${var.group_name}"
+  name  = "${module.label.id}${var.delimiter}group${var.delimiter}membership"
   group = "${aws_iam_group.default.id}"
   users = ["${var.user_names}"]
 }
@@ -27,7 +37,7 @@ data "aws_iam_policy_document" "default" {
 
 # https://www.terraform.io/docs/providers/aws/r/iam_group_policy.html
 resource "aws_iam_group_policy" "default" {
-  name   = "${var.policy_name}"
+  name   = "${module.label.id}${var.delimiter}group${var.delimiter}policy"
   group  = "${aws_iam_group.default.id}"
   policy = "${data.aws_iam_policy_document.default.json}"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -1,8 +1,3 @@
-variable "group_name" {
-  type        = "string"
-  description = "The name of the Group"
-}
-
 variable "user_names" {
   type        = "list"
   description = "A list of IAM User names to associate with the Group"
@@ -16,11 +11,38 @@ variable "member_account_id" {
 variable "role_name" {
   type        = "string"
   default     = "OrganizationAccountAccessRole"
-  description = "The name of the role in the member account to grant permissions to delegated IAM users"
+  description = "The name of the Role in the member account to grant permissions to the users in the Group"
 }
 
-variable "policy_name" {
+variable "namespace" {
   type        = "string"
-  default     = "OrganizationAccountAccessPolicy"
-  description = "The name of the policy to attach to the Group"
+  description = "Namespace (e.g. `cp` or `cloudposse`)"
+}
+
+variable "stage" {
+  type        = "string"
+  description = "Stage (e.g. `prod`, `dev`, `staging`, `infra`)"
+}
+
+variable "name" {
+  type        = "string"
+  description = "Name  (e.g. `app` or `cluster`)"
+}
+
+variable "delimiter" {
+  type        = "string"
+  default     = "-"
+  description = "Delimiter to be used between `namespace`, `stage`, `name`, and `attributes`"
+}
+
+variable "attributes" {
+  type        = "list"
+  default     = []
+  description = "Additional attributes (e.g. `policy` or `role`)"
+}
+
+variable "tags" {
+  type        = "map"
+  default     = {}
+  description = "Additional tags (e.g. map('BusinessUnit`,`XYZ`)"
 }


### PR DESCRIPTION
## what
* Auto-generate Group and Policy names

## why
* This is a generic pattern to name created resources
* Don't require the operators of the module to choose the names
