### PR TITLE
Add enabled var to booloean creation of resources

### DIFF
--- a/output.tf
+++ b/output.tf
@@ -1,20 +1,20 @@
 output "group_name" {
-  value       = "${aws_iam_group.default.name}"
+  value       = "${join("", aws_iam_group.default.*.name)}"
   description = "The Group's name"
 }
 
 output "group_id" {
-  value       = "${aws_iam_group.default.id}"
+  value       = "${join("", aws_iam_group.default.*.id)}"
   description = "The Group's ID"
 }
 
 output "group_unique_id" {
-  value       = "${aws_iam_group.default.unique_id}"
+  value       = "${join("", aws_iam_group.default.*.unique_id)}"
   description = "Group's unique ID assigned by AWS"
 }
 
 output "group_arn" {
-  value       = "${aws_iam_group.default.arn}"
+  value       = "${join("", aws_iam_group.default.*.arn)}"
   description = "The ARN assigned by AWS for the Group"
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -20,6 +20,12 @@ variable "require_mfa" {
   description = "Require the users to have MFA enabled"
 }
 
+variable "enabled" {
+  type        = "string"
+  description = "Whether to create these resources"
+  default     = "true"
+}
+
 variable "namespace" {
   type        = "string"
   description = "Namespace (e.g. `cp` or `cloudposse`)"


### PR DESCRIPTION
## what

This commit adds an “enabled” flag and defaults to true.

## why

So we can enable/disable creation of these resources. Should resolve https://github.com/cloudposse/terraform-aws-organization-access-group/issues/9