### PR TITLE
Use non greedy aws_iam_user_group_membership

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -19,12 +19,11 @@ resource "aws_iam_group" "default" {
   name  = "${module.label.id}"
 }
 
-# https://www.terraform.io/docs/providers/aws/r/iam_group_membership.html
-resource "aws_iam_group_membership" "default" {
-  count = "${local.enabled ? 1 : 0}"
-  name  = "${module.label.id}"
-  group = "${join("", aws_iam_group.default.*.id)}"
-  users = ["${var.user_names}"]
+# https://www.terraform.io/docs/providers/aws/r/iam_user_group_membership.html
+resource "aws_iam_user_group_membership" "default" {
+  count  = "${local.enabled && length(var.user_names) > 0 ? length(var.user_names) : 0}"
+  user   = "${element(var.user_names, count.index)}"
+  groups = ["${join("", aws_iam_group.default.*.id)}"]
 }
 
 # https://www.terraform.io/docs/providers/aws/d/iam_policy_document.html


### PR DESCRIPTION
## what
aws_iam_group_membership [1] is a greedy resource that can cause
inconsistent behaviour. The resource will conflict with itself if used more 
than once with the same group. To non-exclusively manage the users in a 
group switch to the aws_iam_user_group_membership [2] resource which 
can be used multiple times with the same user for non-overlapping groups.

## why
Note that terraform-aws-iam-user [3] is using the 
aws_iam_user_group_membership resource. This mix is causing issues when 
running root account level Terraform. `users` is run and any subsequent 
runs of `iam` (which calls this module) is greedily removing users from
groups that were associated in the `users` run.

## testing

I managed to reproduce this issue on testing after bumping `root.cloudposse.co` [terraform-root-modules](https://github.com/cloudposse/root.cloudposse.co/blob/master/conf/users/terraform.tfvars#L6) to current release.

 Applying `users` followed by `iam`, users are not removed from any groups.

[1] https://www.terraform.io/docs/providers/aws/r/iam_group_membership.html
[2] https://www.terraform.io/docs/providers/aws/r/iam_user_group_membership.html
[3] https://github.com/cloudposse/terraform-aws-iam-user/blob/master/main.tf#L20-L25